### PR TITLE
Don't confuse search terms with arguments

### DIFF
--- a/eacl.el
+++ b/eacl.el
@@ -175,7 +175,7 @@ next text.
 If REGEX is not nil, complete statement."
   (let* ((default-directory (or (funcall eacl-project-root-callback) default-directory))
          (quoted-keyword (eacl-shell-quote-argument keyword))
-         (cmd (format (if regex "%s -rshzoI %s \"%s\" *" "%s -rshI %s \"%s\" *")
+         (cmd (format (if regex "%s -rshzoI %s -- \"%s\" *" "%s -rshI %s -- \"%s\" *")
                       eacl-grep-program
                       (eacl-grep-exclude-opts)
                       (if regex (concat quoted-keyword regex) quoted-keyword)))


### PR DESCRIPTION
If searching for a line `- foo`, we would encode this as `-[[:space:]]foo` and grep would erroneously think this was a malformed argument:

    $ grep "-[[:space:]]" some_directory
    grep: invalid option -- '['
    Usage: grep [OPTION]... PATTERN [FILE]...
    Try 'grep --help' for more information.